### PR TITLE
specfile: package dependencies for grub2, grub2-rpm-ostree

### DIFF
--- a/greenboot.spec
+++ b/greenboot.spec
@@ -43,6 +43,7 @@ Recommends:         openssh
 Summary:            Scripts for greenboot on rpm-ostree-based systems using the Grub2 bootloader
 Requires:           %{name} = %{version}-%{release}
 Requires:           %{name}-grub2 = %{version}-%{release}
+Requires:           rpm-ostree
 
 %description rpm-ostree-grub2
 %{summary}.

--- a/greenboot.spec
+++ b/greenboot.spec
@@ -50,6 +50,7 @@ Requires:           %{name}-grub2 = %{version}-%{release}
 %package grub2
 Summary:            Grub2 specific scripts for greenboot
 Requires:           %{name} = %{version}-%{release}
+Requires:           grub2-tools-minimal
 
 %description grub2
 %{summary}.


### PR DESCRIPTION
I built an image via [osbuild](http://www.osbuild.org), where `grub2-tools-minimal` was not automatically included in the image, and thus greenboot failed to set the boot status:

```
greenboot-grub2-set-success.service: Main process exited, code=exited, status=1/FAILURE
greenboot-grub2-set-success.service: Failed with result 'exit-code'.
[FAILED] Failed to start Mark boot as successful in grubenv.
```
Fix that by explicitly require `grub2-tools-minimal` in the `grub2` sub-package. Also add `rpm-ostree` as a requirement for the `rpm-ostree-grub2` subpackage which uses `rpm-ostree fallback`.