### PR TITLE
Requirement of systemd version >= 240 set in spec file

### DIFF
--- a/greenboot.spec
+++ b/greenboot.spec
@@ -14,7 +14,7 @@ Source0:            https://github.com/%{repo_owner}/%{repo_name}/archive/%{repo
 BuildArch:          noarch
 BuildRequires:      systemd-rpm-macros
 %{?systemd_requires}
-Requires:           systemd
+Requires:           systemd >= 240
 
 %description
 %{summary}.


### PR DESCRIPTION
As @gicmo explained in #35, Greenboot requires `boot-complete.target`, which was included in [systemd 240](https://github.com/systemd/systemd/commit/329d20db3cb02d789473b8f7e4a59526fcbf5728). Hence, specifying this requirement in the spec file.

Fixes #35.

