### PR TITLE
#48 Fix source URL and repo_tag in specfile for Packit

### DIFF
--- a/greenboot.spec
+++ b/greenboot.spec
@@ -8,10 +8,10 @@ License:            LGPLv2+
 
 %global repo_owner  fedora-iot
 %global repo_name   %{name}
-%global repo_tag    v%{version}
+%global repo_tag    %{version}
 
 URL:                https://github.com/%{repo_owner}/%{repo_name}
-Source0:            https://github.com/%{repo_owner}/%{repo_name}/archive/%{repo_tag}.tar.gz
+Source0:            https://github.com/%{repo_owner}/%{repo_name}/archive/refs/tags/%{repo_tag}.tar.gz
 
 ExcludeArch: s390x
 BuildRequires:      systemd-rpm-macros


### PR DESCRIPTION
Closes #48 

Packit had a problem proposing downstream https://github.com/fedora-iot/greenboot/issues/48. This PR attempts to fix that.