### PR TITLE
#48 Add upstream_tag_template on packit file to fix release problems

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,7 @@ synced_files:
   - greenboot.spec
   - .packit.yaml
 upstream_package_name: greenboot
+upstream_tag_template: v{version}
 downstream_package_name: greenboot
 jobs:
   - job: sync_from_downstream


### PR DESCRIPTION
Related to #48 

Taking a look on [Packit documentation](https://packit.dev/docs/configuration/#upstream_tag_template):

**upstream_tag_template**
_(string)_ Packit by default expects git tags to match versions (e.g. when doing the `propose-downstream` command) - if you are using a different tagging scheme, let’s say `v1.2.3` you can then set this parameter to `v{version}` and packit will fill in the version argument.

We do are using `v1.2.3` as tagging scheme, hence adding this parameter and set it to `v{version}`.