### PR TITLE
set-success.service: Change RequiredBy to WantedBy=multi-user.target

### DIFF
--- a/usr/lib/systemd/system/greenboot-grub2-set-success.service
+++ b/usr/lib/systemd/system/greenboot-grub2-set-success.service
@@ -19,4 +19,4 @@ ExecStart=/usr/bin/grub2-editenv - set boot_success=1
 ExecStart=/usr/bin/grub2-editenv - unset boot_counter
 
 [Install]
-RequiredBy=multi-user.target
+WantedBy=multi-user.target


### PR DESCRIPTION
This change weakens the dependency of `multi-user.target` on the
set-success service. This is so that `multi-user.target` can be reached
before `boot-complete.target`, for which this service is a requirement.
This new behavior will enable services such as systemd's
`systemd-boot-check-no-failures.service`, which runs after
`multi-user.target` but still gates whether `boot-complete.target` can
be reached or not.