### PR TITLE
Fix ordering cycles starting with multi-user.target

### DIFF
--- a/greenboot.spec
+++ b/greenboot.spec
@@ -90,6 +90,7 @@ install -DpZm 0644 etc/greenboot/greenboot.conf %{buildroot}%{_sysconfdir}/%{nam
 %systemd_post greenboot-rpm-ostree-grub2-check-fallback.service
 %systemd_post redboot-auto-reboot.service
 %systemd_post greenboot-service-monitor.service
+%systemd_post greenboot-success.target
 
 %post default-health-checks
 %systemd_post greenboot-loading-message.service
@@ -105,6 +106,7 @@ install -DpZm 0644 etc/greenboot/greenboot.conf %{buildroot}%{_sysconfdir}/%{nam
 %systemd_preun greenboot-grub2-set-success.service
 %systemd_preun greenboot-rpm-ostree-grub2-check-fallback.service
 %systemd_preun greenboot-service-monitor.service
+%systemd_preun greenboot-success.target
 
 %preun default-health-checks
 %systemd_preun greenboot-loading-message.service
@@ -120,6 +122,7 @@ install -DpZm 0644 etc/greenboot/greenboot.conf %{buildroot}%{_sysconfdir}/%{nam
 %systemd_postun greenboot-grub2-set-success.service
 %systemd_postun greenboot-rpm-ostree-grub2-check-fallback.service
 %systemd_postun greenboot-service-monitor.service
+%systemd_postun greenboot-success.target
 
 %postun default-health-checks
 %systemd_postun greenboot-loading-message.service
@@ -133,6 +136,7 @@ install -DpZm 0644 etc/greenboot/greenboot.conf %{buildroot}%{_sysconfdir}/%{nam
 %{_unitdir}/greenboot-healthcheck.service
 %{_unitdir}/greenboot-loading-message.service
 %{_unitdir}/greenboot-task-runner.service
+%{_unitdir}/greenboot-success.target
 %{_unitdir}/redboot-task-runner.service
 %{_unitdir}/redboot.target
 %dir %{_prefix}/lib/%{name}

--- a/usr/lib/systemd/system/greenboot-grub2-set-success.service
+++ b/usr/lib/systemd/system/greenboot-grub2-set-success.service
@@ -19,4 +19,4 @@ ExecStart=/usr/bin/grub2-editenv - set boot_success=1
 ExecStart=/usr/bin/grub2-editenv - unset boot_counter
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=greenboot-success.target

--- a/usr/lib/systemd/system/greenboot-status.service
+++ b/usr/lib/systemd/system/greenboot-status.service
@@ -19,4 +19,4 @@ RemainAfterExit=yes
 ExecStart=/usr/libexec/greenboot/greenboot-status
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=greenboot-success.target

--- a/usr/lib/systemd/system/greenboot-success.target
+++ b/usr/lib/systemd/system/greenboot-success.target
@@ -8,14 +8,6 @@
 #  (at your option) any later version.
 
 [Unit]
-Description=greenboot Success Scripts Runner
-Requires=boot-complete.target
+Description=greenboot success target
 After=boot-complete.target
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=/usr/libexec/greenboot/greenboot green
-
-[Install]
-WantedBy=greenboot-success.target
+Requires=boot-complete.target multi-user.target


### PR DESCRIPTION
This change introduces a new greenboot-success.target which requires
boot-complete.target and multi-user.target.
This is to avoid an ordering cycle that was introduced with the recent
addition of the service monitor, which explicitly orders
multi-user.target before boot-complete.target.
The start of services that were either WantedBy= or
RequiredBy=multi-user.target but which also had to run
After=boot-complete.target, couldn't be ordered properly
anymore. This change fixes that.

An unfortunate side-effect of this is that `multi-user.target` can't be
used as the default target anymore. The default target now has to be
changed to `greenboot-success.target` for greenboot to run.

---

If we go ahead with this approach, the `default_target` in the Fedora IoT/RHEL for Edge
rpm-ostree manifests will have to be changed to `greenboot-success.target`.
For Fedora IoT, the default target is specified here: https://pagure.io/fedora-iot/ostree/blob/main/f/fedora-iot-base.json#_126

@runcom @say-paul