### PR TITLE
disable DefaultDependencies to fix cycle error

### DIFF
--- a/usr/lib/systemd/system/greenboot-grub2-set-success.service
+++ b/usr/lib/systemd/system/greenboot-grub2-set-success.service
@@ -11,6 +11,8 @@
 Description=Mark boot as successful in grubenv
 Requires=boot-complete.target
 After=boot-complete.target
+Conflicts=redboot.target
+DefaultDependencies=no
 
 [Service]
 Type=oneshot

--- a/usr/lib/systemd/system/greenboot-status.service
+++ b/usr/lib/systemd/system/greenboot-status.service
@@ -12,6 +12,7 @@ Description=greenboot MotD Generator
 After=greenboot-healthcheck.service
 After=greenboot-task-runner.service
 After=redboot-task-runner.service
+DefaultDependencies=no
 
 [Service]
 Type=oneshot

--- a/usr/lib/systemd/system/greenboot-task-runner.service
+++ b/usr/lib/systemd/system/greenboot-task-runner.service
@@ -11,6 +11,8 @@
 Description=greenboot Success Scripts Runner
 Requires=boot-complete.target
 After=boot-complete.target
+Conflicts=redboot.target
+DefaultDependencies=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The fix relaxes the dependecies of task-runner and status service that
otherwise causes issue in the service to start as well as fix the missing
logs
signed off: saypaul@fedoraproject.org