### PR TITLE
greenboot-grub2-set-counter.service: ensure /boot is mounted

### DIFF
--- a/usr/lib/systemd/system/greenboot-grub2-set-counter.service
+++ b/usr/lib/systemd/system/greenboot-grub2-set-counter.service
@@ -12,6 +12,7 @@ Description=Set grub2 boot counter in preparation of upgrade
 DefaultDependencies=no
 Before=ostree-finalize-staged.service
 Conflicts=greenboot-grub2-set-success.service
+RequiresMountsFor=/boot
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2121944 . As it stands, this service can actually race with the mounting of /boot, and fail if it starts before /boot is mounted. Adding this ensures that doesn't happen.

Signed-off-by: Adam Williamson <awilliam@redhat.com>