### PR TITLE
greenboot: fix exit status with unknown argument

### DIFF
--- a/tests/greenboot_check.bats
+++ b/tests/greenboot_check.bats
@@ -11,10 +11,10 @@ function setup() {
   mv $GREENBOOT_DEFAULT_CHECK_PATH/wanted.d/* $GREENBOOT_ETC_CHECK_PATH/wanted.d/
 }
 
-@test "Test greenboot with illegal command" {
+@test "Test greenboot with unknown argument" {
   run $GREENBOOT_BIN_PATH bananas
-  [ "$status" -eq 127 ]
-  [ "$output" = "Illegal Command" ]
+  [ "$status" -eq 1 ]
+  [ "$output" = "Unknown argument, exiting." ]
 }
 
 @test "Test greenboot check with the default hc scripts" {

--- a/usr/libexec/greenboot/greenboot
+++ b/usr/libexec/greenboot/greenboot
@@ -51,6 +51,6 @@ case "$1" in
     script_runner "/etc/greenboot/red.d" "relaxed" "Running Red Scripts..."
     ;;
   *)
-    echo "Illegal Command" >&2
-    exit 127
+    echo "Unknown argument, exiting." >&2
+    exit 1
 esac


### PR DESCRIPTION
Greenboot uses exit code "127" when it encounters an unknown argument. This is also used by bash for "command not found" and causes issues with the bats in CI. This PR moves the exit code to a generic "exit 1" and updates the associated error message and bats test. 

Signed-off-by: Paul Whalen <pwhalen@fedoraproject.org>