### PR TITLE
packit: add koji, bodhi jobs, upstream url

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,3 +1,5 @@
+upstream_project_url: https://github.com/fedora-iot/greenboot
+
 specfile_path: greenboot.spec
 files_to_sync:
   - greenboot.spec
@@ -5,14 +7,30 @@ files_to_sync:
 upstream_package_name: greenboot
 upstream_tag_template: v{version}
 downstream_package_name: greenboot
+
 jobs:
+
   - job: sync_from_downstream
     trigger: commit
+
   - job: propose_downstream
     trigger: release
     dist_git_branches:
       - fedora-all
+
   - job: tests
     trigger: pull_request
     targets:
       - fedora-all
+
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-development
+      - fedora-37
+
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      # rawhide updates are created automatically
+      - fedora-37


### PR DESCRIPTION
This commit adds koji_build and bodhi_update jobs to automate build and bodhi submissions of new releases.  Also adds upstream_project_url. 

Signed-off-by: Paul Whalen <pwhalen@fedoraproject.org>