### PR TITLE
watchdog.sh: do not exit in --source-only

### DIFF
--- a/usr/lib/greenboot/check/required.d/02_watchdog.sh
+++ b/usr/lib/greenboot/check/required.d/02_watchdog.sh
@@ -42,14 +42,14 @@ check_if_current_boot_is_wd_triggered() {
     fi
 }
 
-if ! check_if_there_is_a_watchdog ; then
-  echo "No watchdog on the system, skipping check"
-  exit 0
-fi
-
 # This is in order to test check_if_current_boot_is_wd_triggered
 # function within a container
 if [ "${1}" != "--source-only" ]; then
+  if ! check_if_there_is_a_watchdog ; then
+    echo "No watchdog on the system, skipping check"
+    exit 0
+  fi
+
   source_configuration_file
   if [ "${GREENBOOT_WATCHDOG_CHECK_ENABLED,,}" != "true" ]; then
     echo "Watchdog check is disabled"


### PR DESCRIPTION
`bats` will source `02_watchdog.sh`. Move all checks that may exit in the branch when `--source-only` is not passed to avoid a false negative in bats.

`wdctl` may return:
```
# wdctl 
wdctl: No default device is available.: No such file or directory
```

Using the provided Dockerfile environment (with [5a9d47e8767d0059b395de86991e816b5511fc41](https://github.com/fedora-iot/greenboot/commit/5a9d47e8767d0059b395de86991e816b5511fc41)):
```
$ podman build -t fc37-greenboot-test .
$ podman run --rm -v /run/systemd/journal:/run/systemd/journal -it fc37-greenboot-test
check_watchdog_support.bats
 ✗ Ensure watchdog check is working
   (from function `source' in file /usr/lib/greenboot/check/required.d/02_watchdog.sh, line 47,
    from function `setup' in test file check_watchdog_support.bats, line 4)
     `source $GREENBOOT_DEFAULT_CHECK_PATH/required.d/02_watchdog.sh --source-only' failed
   No watchdog on the system, skipping check
[...]
```