### PR TITLE
chore: update packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,13 +26,9 @@ jobs:
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-development
-      - fedora-37
-      - fedora-38
+      - fedora-all
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
-      # rawhide updates are created automatically
-      - fedora-37
-      - fedora-38
+      - fedora-all


### PR DESCRIPTION
Update packit configs to build all current Fedora
releases so we don't need to update this file.