### PR TITLE
Add static grub config

### DIFF
--- a/greenboot.spec
+++ b/greenboot.spec
@@ -19,6 +19,7 @@ BuildRequires:      systemd-rpm-macros
 Requires:           systemd >= 240
 Requires:           grub2-tools-minimal
 Requires:           rpm-ostree
+Requires:           bootupd
 # PAM is required to programatically read motd messages from /etc/motd.d/*
 # This causes issues with RHEL-8 as the fix isn't there an el8 is on pam-1.3.x
 Requires:           pam >= 1.4.0
@@ -65,6 +66,7 @@ mkdir -p %{buildroot}%{_prefix}/lib/%{name}/check/required.d
 mkdir    %{buildroot}%{_prefix}/lib/%{name}/check/wanted.d
 mkdir    %{buildroot}%{_prefix}/lib/%{name}/green.d
 mkdir    %{buildroot}%{_prefix}/lib/%{name}/red.d
+install -D -t %{buildroot}%{_prefix}/lib/bootupd/grub2-static/configs.d grub2/greenboot.cfg
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_unitdir}/greenboot-healthcheck.service.d
 mkdir -p %{buildroot}%{_tmpfilesdir}
@@ -149,6 +151,7 @@ install -DpZm 0644 etc/greenboot/greenboot.conf %{buildroot}%{_sysconfdir}/%{nam
 %{_exec_prefix}/lib/motd.d/boot-status
 %{_libexecdir}/%{name}/greenboot-status
 %{_tmpfilesdir}/greenboot-status-motd.conf
+%{_prefix}/lib/bootupd/grub2-static/configs.d/*.cfg
 %{_unitdir}/greenboot-status.service
 %{_libexecdir}/%{name}/greenboot-grub2-set-counter
 %{_unitdir}/greenboot-grub2-set-success.service

--- a/grub2/greenboot.cfg
+++ b/grub2/greenboot.cfg
@@ -1,0 +1,20 @@
+# greenboot support, aka boot counter and boot success reporting
+# This will be installed via bootupd
+insmod increment
+# Check if boot_counter exists and boot_success=0 to activate this behaviour.
+if [ -n "${boot_counter}" -a "${boot_success}" = "0" ]; then
+  # if countdown has ended, choose to boot rollback deployment,
+  # i.e. default=1 on OSTree-based systems.
+  if  [ "${boot_counter}" = "0" -o "${boot_counter}" = "-1" ]; then
+    set default=1
+    set boot_counter=-1
+  # otherwise decrement boot_counter
+  else
+    decrement boot_counter
+  fi
+  save_env boot_counter
+fi
+
+# Reset boot_success for current boot
+set boot_success=0
+save_env boot_success


### PR DESCRIPTION
This pairs with https://github.com/coreos/bootupd/pull/543 to have bootupd support injecting the greenboot grub logic only if greenboot is installed.