### PR TITLE
greenboot: add feature to disable healthchecks

### DIFF
--- a/etc/greenboot/greenboot.conf
+++ b/etc/greenboot/greenboot.conf
@@ -13,3 +13,15 @@ GREENBOOT_WATCHDOG_CHECK_ENABLED=true
 ### the new deployment as culprit of reboot.
 ### It has to be a positive integer. Defaults to 24 (hours).
 # GREENBOOT_WATCHDOG_GRACE_PERIOD=24
+
+### This variable allows you to specify healthchecks to be skipped. 
+### The healthcheck must be specified by script name, as in the 
+### example below. Multiple healthchecks may be skipped by separating
+### the script names with spaces.
+### NOTE: Script names must be spelled EXACTLY. Typos will result in
+### unwanted behaviour.
+### DISABLED_HEALTHCHECKS=(
+### 	"01_repository_dns_check.sh" 
+### 	"02_watchdog.sh"
+### )
+DISABLED_HEALTHCHECKS=()

--- a/usr/libexec/greenboot/greenboot
+++ b/usr/libexec/greenboot/greenboot
@@ -7,6 +7,23 @@ SCRIPTS_CHECK_PATHS=("/usr/lib/greenboot/check" "/etc/greenboot/check")
 SCRIPTS_GREEN_PATHS=("/usr/lib/greenboot/green.d" "/etc/greenboot/green.d")
 SCRIPTS_RED_PATHS=("/usr/lib/greenboot/red.d" "/etc/greenboot/red.d")
 
+source_configuration_file() {
+    greenboot_configuration_file=/etc/greenboot/greenboot.conf
+    if test -f "$greenboot_configuration_file"; then
+	# shellcheck source=/etc/greenboot/greenboot.conf
+        source $greenboot_configuration_file
+    fi
+}
+
+source_configuration_file
+function is_disabled {
+    healthcheck=$1
+    for disabled_healthcheck in "${DISABLED_HEALTHCHECKS[@]}"; do
+        if [ "${healthcheck}" == "${disabled_healthcheck}" ]; then return 0; fi
+    done
+    return 1
+}
+
 script_runner () {
   local scripts_dir=$1; shift
   local mode=$1; shift
@@ -14,21 +31,25 @@ script_runner () {
   local required_hc_failed=false
   echo "$start_msg"
   for script in $(find "$scripts_dir" -name '*.sh' | sort); do
-    local rc=0
-    systemd-cat -t "$(basename "$script")" bash "$script" || rc=$?
-    if [ $rc -ne 0 ]; then
-      local failure_msg
-      failure_msg="Script '$(basename "$script")' FAILURE (exit code '$rc')"
-      case "$mode" in
-        "relaxed")
-          echo "<2>$failure_msg. Continuing..." >&2
-          ;;
-        "strict")
-          required_hc_failed=true
-          echo "<0>$failure_msg. Continuing..." >&2
-      esac
+    if is_disabled "$(basename "$script")"; then
+      echo "'$(basename "$script")' was skipped, as specified in config"
     else
-      echo "<6>Script '$(basename "$script")' SUCCESS"
+      local rc=0
+      systemd-cat -t "$(basename "$script")" bash "$script" || rc=$?
+      if [ $rc -ne 0 ]; then
+        local failure_msg
+        failure_msg="Script '$(basename "$script")' FAILURE (exit code '$rc')"
+        case "$mode" in
+          "relaxed")
+            echo "<2>$failure_msg. Continuing..." >&2
+            ;;
+          "strict")
+            required_hc_failed=true
+            echo "<0>$failure_msg. Continuing..." >&2
+        esac
+      else
+        echo "<6>Script '$(basename "$script")' SUCCESS"
+      fi
     fi
   done
 


### PR DESCRIPTION
Addresses #119. Allows users to specify healthchecks to be skipped via a DISABLED_HEALTHCHECKS variable in greenboot.conf. Skipped healthchecks will be reflected with an appropriate message in the logs.