### PR TITLE
greenboot: warn users of missing disabled healthchecks

### DIFF
--- a/usr/libexec/greenboot/greenboot
+++ b/usr/libexec/greenboot/greenboot
@@ -6,6 +6,7 @@ LC_ALL=C
 SCRIPTS_CHECK_PATHS=("/usr/lib/greenboot/check" "/etc/greenboot/check")
 SCRIPTS_GREEN_PATHS=("/usr/lib/greenboot/green.d" "/etc/greenboot/green.d")
 SCRIPTS_RED_PATHS=("/usr/lib/greenboot/red.d" "/etc/greenboot/red.d")
+declare -A DIS_CHECK_STATUS=()
 
 source_configuration_file() {
     greenboot_configuration_file=/etc/greenboot/greenboot.conf
@@ -16,13 +17,34 @@ source_configuration_file() {
 }
 
 source_configuration_file
+function init_disabled_map {
+    for disabled_healthcheck in "${DISABLED_HEALTHCHECKS[@]}"; do
+	DIS_CHECK_STATUS["$disabled_healthcheck"]=1;
+    done
+}
+
+source_configuration_file
+function print_unexecuted_checks {
+    for disabled_healthcheck in "${DISABLED_HEALTHCHECKS[@]}"; do
+	if [[  "${DIS_CHECK_STATUS[$disabled_healthcheck]}" == 1 ]]; then
+    	    echo "WARNING: $disabled_healthcheck was not found and may be misspelled"
+	fi
+    done
+}
+
+source_configuration_file
 function is_disabled {
     healthcheck=$1
     for disabled_healthcheck in "${DISABLED_HEALTHCHECKS[@]}"; do
-        if [ "${healthcheck}" == "${disabled_healthcheck}" ]; then return 0; fi
+        if [ "${healthcheck}" == "${disabled_healthcheck}" ]; then
+	    DIS_CHECK_STATUS["${disabled_healthcheck}"]=0
+	    return 0
+	fi
     done
     return 1
 }
+
+init_disabled_map
 
 script_runner () {
   local scripts_dir=$1; shift
@@ -63,6 +85,7 @@ case "$1" in
       script_runner "$health_check_path/required.d" "strict" "Running Required Health Check Scripts..." || rc=1
       script_runner "$health_check_path/wanted.d" "relaxed" "Running Wanted Health Check Scripts..."
     done
+    print_unexecuted_checks
     exit $rc
     ;;
   "green")


### PR DESCRIPTION
Resolves #139. Prints a warning in the logs when a user specifies a healthcheck to be disabled that cannot be found.