### PR TITLE
packit.yaml: add copy_upstream_release_description true

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,6 +6,7 @@ files_to_sync:
   - .packit.yaml
 upstream_package_name: greenboot
 upstream_tag_template: v{version}
+copy_upstream_release_description: true
 downstream_package_name: greenboot
 
 jobs:

--- a/greenboot.spec
+++ b/greenboot.spec
@@ -4,7 +4,7 @@ Name:               greenboot
 Version:            0.15.5
 Release:            2%{?dist}
 Summary:            Generic Health Check Framework for systemd
-License:            LGPLv2+
+License:            LGPL-2.1-or-later
 
 %global repo_owner  fedora-iot
 %global repo_name   %{name}
@@ -171,8 +171,7 @@ install -DpZm 0644 etc/greenboot/greenboot.conf %{buildroot}%{_sysconfdir}/%{nam
 %{_prefix}/lib/%{name}/check/required.d/02_watchdog.sh
 
 %changelog
-
-* Tue Jun 18 2024 Peter Robinson <pbrobinson@fedoraproject.org> - 0.15.5-2
+* Thu Aug 22 2024 Peter Robinson <pbrobinson@fedoraproject.org> - 0.15.5-2
 - Reorder files, don't overwrite configs on update
 
 * Fri Aug 16 2024 saypaul <paul.sayan@gmail.com> - 0.15.5-1


### PR DESCRIPTION
- Added `copy_upstream_release_description true` to packit.yaml to fix missing downstream change log entries.
- fix date entry in change log
- migrated to SPDX license (dist-git change)