### PR TITLE
packit: only use IoT relevant branches

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,8 +13,8 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-    - fedora-all
-  
+      - fedora-development
+      - fedora-latest-stable
 
   - job: sync_from_downstream
     trigger: commit
@@ -22,19 +22,23 @@ jobs:
   - job: propose_downstream
     trigger: release
     dist_git_branches:
-      - fedora-all
+      - fedora-development
+      - fedora-latest-stable
 
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-all
+      - fedora-development
+      - fedora-latest-stable
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-all
+      - fedora-development
+      - fedora-latest-stable
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
-      - fedora-all
+      - fedora-development
+      - fedora-latest-stable


### PR DESCRIPTION
Since IoT uses a rolling `stable` ref, we don't need action on the n-1 "stable" branch in Fedora dist-git. (i.e. stable is currently F40, we don't need action on the F39 branch)

Packit has some aliases that let us narrow the scope of versions that the service will operate against. `fedora-development` targets the next major version of Fedora + Rawhide. `fedora-latest-stable` targets exactly one version (the latest version) of stable. See below:

```
>>> from packit.config.aliases import get_aliases
>>> get_aliases()['fedora-development']
['fedora-41', 'fedora-rawhide']
>>> get_aliases()['fedora-latest-stable']
['fedora-40']
```