### PR TITLE
specfile: Stop building on ix86

### DIFF
--- a/greenboot.spec
+++ b/greenboot.spec
@@ -13,7 +13,7 @@ License:            LGPL-2.1-or-later
 URL:                https://github.com/%{repo_owner}/%{repo_name}
 Source0:            https://github.com/%{repo_owner}/%{repo_name}/archive/%{repo_tag}.tar.gz
 
-ExcludeArch: s390x
+ExcludeArch: s390x {%ix86}
 BuildRequires:      systemd-rpm-macros
 %{?systemd_requires}
 Requires:           systemd >= 240


### PR DESCRIPTION
Initially pushed downstream in Fedora [1], but overwrote by packit with the 0.15.7 update [2], thus pushed here.

[1]: https://src.fedoraproject.org/rpms/greenboot/pull-request/30
[2]: https://src.fedoraproject.org/rpms/greenboot/pull-request/35

See: https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval