### PR TITLE
rollback: if no bootc, fallback to rpm-ostree

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
       - if: ${{ always() }}
         name: Upload artifact with ShellCheck defects in SARIF format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}

--- a/usr/libexec/greenboot/greenboot-rpm-ostree-grub2-check-fallback
+++ b/usr/libexec/greenboot/greenboot-rpm-ostree-grub2-check-fallback
@@ -8,10 +8,12 @@ function attempt_rollback {
   if command -v bootc &> /dev/null; then
       status_type=$(bootc status --booted --json 2>/dev/null | jq -r .status.type 2>/dev/null)
       if [ "$status_type" == "bootcHost" ]; then
+	  echo "<3> On a bootc managed host, attempting rollback with bootc."
           bootc rollback
           echo "<3>FALLBACK BOOT DETECTED! Default bootc deployment has been rolled back."
+          return
       fi
-      return
+      echo "<3> Not on a bootc managed host, trying rpm-ostree rollback next."
   fi
   # Check if its ostree based os
   if [ -f /run/ostree-booted ]; then


### PR DESCRIPTION
Newer rpm-ostree in 9.6 pulls in bootc, which made our test fails because we weren't rolling back the deployment.
This patch puts the `return` where it should be in case we're not "bootc-native". That way we can safely fallback to rpm-ostree rollback (bootc rollback should work tho...). A fallout of this nasty bug is that we don't get any logs either so just adding some for mental sanity.