### PR TITLE
Do not remount /boot superblock/filesystem readonly

### DIFF
--- a/usr/libexec/greenboot/greenboot-boot-remount
+++ b/usr/libexec/greenboot/greenboot-boot-remount
@@ -8,7 +8,7 @@ boot_was_ro=false
 # Remount /boot as read-only if it was mounted as read-only ealier
 function remount_boot_ro {
     if $boot_was_ro; then
-        mount -o remount,ro /boot || exit 13
+        mount -o remount,bind,ro /boot || exit 13
     fi
     return
 }


### PR DESCRIPTION
https://man7.org/linux/man-pages/man8/mount.8.html

    Read-only Setting Notes
    The read-only setting (ro or rw) is interpreted by the
    virtual-filesystem and the filesystem, and it depends on how the
    option is specified on the mount(8) command line. For backward
    compatibility, the default is to use it for both layers during
    standard mount operations.

    The operation "-o bind,remount,ro" is applied only to the VFS
    mountpoint, while the operation "-o remount,ro" is applied to both
    the VFS and filesystem superblock. This semantic allows for the
    creation of a read-only mountpoint while keeping the filesystem
    writable from another mountpoint.

If /boot is on the same filesystem as sysroot, `remount,ro` will make the whole system read-only.

To see both vfs and fs ro/rw flags, one can look at /proc/self/mountinfo (or /proc/1/mountinfo)