### PR TITLE
Use mount namespace to simplify code

### DIFF
--- a/usr/libexec/greenboot/greenboot-boot-remount
+++ b/usr/libexec/greenboot/greenboot-boot-remount
@@ -1,23 +1,11 @@
-#!/bin/bash
-set -eo pipefail
-
-# Boolean variable to track if /boot was initially mounted as read-only
-# Ensure compatibility with rpm-ostree where /boot is rw but in bootc /boot is ro
-boot_was_ro=false
-
-# Remount /boot as read-only if it was mounted as read-only ealier
-function remount_boot_ro {
-    if $boot_was_ro; then
-        mount -o remount,bind,ro /boot || exit 13
-    fi
-    return
-}
-
-# Remount /boot as read-write if it was mounted as read-only
-function remount_boot_rw {
-    if grep -q " /boot .* ro," /proc/mounts; then
-        mount -o remount,rw /boot || exit 13
-        boot_was_ro=true
-    fi
-    return
-}
+# skip if /boot is already writable
+if [ ! -w /boot ]; then
+  if [[ "$(readlink /proc/1/ns/mnt)" == "$(readlink /proc/self/ns/mnt)" ]]; then
+      # reexec ourselves to unshare the mount namespace
+      exec unshare -m $0 $@
+  else
+      # we are in a separate mount namespace, we can remount
+      # without impacting the rest of the system
+      mount -o remount,rw /boot
+  fi
+fi

--- a/usr/libexec/greenboot/greenboot-grub2-set-counter
+++ b/usr/libexec/greenboot/greenboot-grub2-set-counter
@@ -17,22 +17,8 @@ else
     max_boot_attempts=3 # default to 3 attempts
 fi
 
+/usr/bin/grub2-editenv - set boot_counter="$max_boot_attempts"
 
-remount_boot_rw
-
-if ! /usr/bin/grub2-editenv - set boot_counter="$max_boot_attempts"; then
- # If the first command fails, remount /boot as read-only and exit with failure
-    remount_boot_ro
-    exit 1
-fi
-
-if ! /usr/bin/grub2-editenv /boot/grub2/grubenv set boot_success=0; then
-    # If the first command fails, remount /boot as read-only and exit with failure
-    remount_boot_ro
-    exit 1
-fi
-
-# Revert /boot as read-only
-remount_boot_ro
+/usr/bin/grub2-editenv /boot/grub2/grubenv set boot_success=0
 
 echo "<3>GRUB2 environment variables have been set for system upgrade. Max boot attempts is $max_boot_attempts"

--- a/usr/libexec/greenboot/greenboot-grub2-set-success
+++ b/usr/libexec/greenboot/greenboot-grub2-set-success
@@ -1,25 +1,9 @@
 #!/bin/bash
-
 set -eo pipefail
 
 source /usr/libexec/greenboot/greenboot-boot-remount
-remount_boot_rw
 
 # Run the grub2-editenv commands
-if ! /usr/bin/grub2-editenv /boot/grub2/grubenv set boot_success=1; then
-    # If the first command fails, remount /boot as read-only and exit with failure
-    remount_boot_ro
-    exit 1
-fi
+/usr/bin/grub2-editenv /boot/grub2/grubenv set boot_success=1
 
-if ! /usr/bin/grub2-editenv /boot/grub2/grubenv unset boot_counter; then
-    # If the second command fails, remount /boot as read-only and exit with failure
-    remount_boot_ro
-    exit 1
-fi
-
-# Remount /boot as read-only if it was mounted as read-write
-remount_boot_ro
-
-# If everything succeeded, exit with success
-exit 0
+/usr/bin/grub2-editenv /boot/grub2/grubenv unset boot_counter

--- a/usr/libexec/greenboot/greenboot-rpm-ostree-grub2-check-fallback
+++ b/usr/libexec/greenboot/greenboot-rpm-ostree-grub2-check-fallback
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+# Determine if the current boot is a fallback boot, if not exit early
+if ! (grub2-editenv list | grep -q "^boot_counter=-1$"); then
+  exit 0
+fi
+
 source /usr/libexec/greenboot/greenboot-boot-remount
 
 function attempt_rollback {
@@ -25,25 +30,13 @@ function attempt_rollback {
   return
 }
 
-# Determine if the current boot is a fallback boot
 # If booted into fallback deployment, clean up bootloader entries (rollback)
-if grub2-editenv list | grep -q "^boot_counter=-1$"; then
-  # Logs from previous boot may be unavailable on systems without internal RTC; defaulting to empty string
-  prev_logs="$(journalctl -u greenboot-healthcheck.service -p 2 -b -1 -o cat)" || true
-  attempt_rollback
-  if [ -n "$prev_logs" ]; then
-    echo "<3>Health check logs from previous boot:"
-    echo "<3>$prev_logs"
-  fi
-
-remount_boot_rw
-
-  if ! /usr/bin/grub2-editenv - unset boot_counter; then
-    # If the above command fails, remount /boot as read-only and exit with failure
-    remount_boot_ro
-    exit 1
-  fi
+# Logs from previous boot may be unavailable on systems without internal RTC; defaulting to empty string
+prev_logs="$(journalctl -u greenboot-healthcheck.service -p 2 -b -1 -o cat)" || true
+attempt_rollback
+if [ -n "$prev_logs" ]; then
+  echo "<3>Health check logs from previous boot:"
+  echo "<3>$prev_logs"
 fi
 
-# Remount /boot as read-only if it was mounted as read-write
-remount_boot_ro
+/usr/bin/grub2-editenv - unset boot_counter


### PR DESCRIPTION
With mount namespace we don't need to remount `/boot` read only before exit.
Also do not try to parse /proc/self/mountinfo, just use '-w' test flag.

If a command is called directly without systemd, reexec ourselves with `unshare -m`.